### PR TITLE
Oppdatert builder etter endring i xsd

### DIFF
--- a/fiks-arkiv-api/src/main/xjb/bindings.xjb
+++ b/fiks-arkiv-api/src/main/xjb/bindings.xjb
@@ -35,17 +35,17 @@
     </jaxb:bindings>
     <jaxb:bindings schemaLocation="../../../target/schemas/v1/dokumentfilHent.xsd">
         <jaxb:schemaBindings>
-            <jaxb:package name="no.ks.fiks.io.arkiv.v1.client.models.innsyn.hent" />
+            <jaxb:package name="no.ks.fiks.io.arkiv.v1.client.models.innsyn.dokument" />
         </jaxb:schemaBindings>
     </jaxb:bindings>
     <jaxb:bindings schemaLocation="../../../target/schemas/v1/journalpostHent.xsd">
         <jaxb:schemaBindings>
-            <jaxb:package name="no.ks.fiks.io.arkiv.v1.client.models.innsyn.hent" />
+            <jaxb:package name="no.ks.fiks.io.arkiv.v1.client.models.innsyn.journalpost" />
         </jaxb:schemaBindings>
     </jaxb:bindings>
     <jaxb:bindings schemaLocation="../../../target/schemas/v1/mappeHent.xsd">
         <jaxb:schemaBindings>
-            <jaxb:package name="no.ks.fiks.io.arkiv.v1.client.models.innsyn.hent" />
+            <jaxb:package name="no.ks.fiks.io.arkiv.v1.client.models.innsyn.mappe" />
         </jaxb:schemaBindings>
     </jaxb:bindings>
     <jaxb:bindings schemaLocation="../../../target/schemas/v1/sok.xsd">

--- a/fiks-arkiv-api/src/test/kotlin/no/ks/fiks/io/arkiv/model/ArkivmeldingTest.kt
+++ b/fiks-arkiv-api/src/test/kotlin/no/ks/fiks/io/arkiv/model/ArkivmeldingTest.kt
@@ -2,17 +2,17 @@ package no.ks.fiks.io.arkiv.model
 
 import io.kotest.matchers.shouldBe
 import io.kotest.assertions.throwables.shouldNotThrowAny
+import mu.KotlinLogging
 import no.arkivverket.standarder.noark5.metadatakatalog.v2.Journalposttype
 import no.arkivverket.standarder.noark5.metadatakatalog.v2.Journalstatus
 import no.arkivverket.standarder.noark5.metadatakatalog.v2.Korrespondanseparttype
 import no.arkivverket.standarder.noark5.metadatakatalog.v2.SystemID
-import no.ks.fiks.io.arkiv.v1.client.models.arkivmelding.Arkivmelding
-import no.ks.fiks.io.arkiv.v1.client.models.arkivmelding.Journalpost
-import no.ks.fiks.io.arkiv.v1.client.models.arkivmelding.Korrespondansepart
+import no.ks.fiks.io.arkiv.v1.client.models.arkivmelding.*
 import no.ks.fiks.io.arkiv.v1.client.models.arkivstruktur.EksternNoekkel
 import org.junit.jupiter.api.Test
 import java.io.File
 import java.io.StringWriter
+import java.math.BigInteger
 import java.time.LocalDate
 import java.time.ZonedDateTime
 import java.util.*
@@ -23,6 +23,9 @@ import javax.xml.bind.JAXBContext
 import javax.xml.bind.JAXBElement
 import javax.xml.bind.Marshaller
 import javax.xml.namespace.QName
+
+
+private val logger = KotlinLogging.logger {}
 
 class ArkivmeldingTest {
 
@@ -46,9 +49,8 @@ class ArkivmeldingTest {
                 it.opprettetAv = "Ole"
                 it.arkivertAv = "Kari"
                 it.arkivertDato = arkivertDato
-                it.referanseForelderMappe = SystemID().also {
-                    it.label = "ReferanseMappe"
-                    it.value = UUID.randomUUID().toString()
+                it.referanseForelderMappe = ReferanseForelderMappe().also {
+                    it.saksnummer = Saksnummer().also { it.saksaar = BigInteger.valueOf(2022); it.sakssekvensnummer = BigInteger.valueOf(100) }
                 }
                 it.referanseEksternNoekkel = EksternNoekkel().also {
                     it.noekkel = "Nøkkel"
@@ -88,12 +90,12 @@ class ArkivmeldingTest {
             Arkivmelding::class.java,
             arkivmelding)
 
-        shouldNotThrowAny {
-            validator.validate(JAXBSource(jaxbContext, element))}
-
         val sw = StringWriter()
         val marshaller = jaxbContext.createMarshaller().also { it.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true) }
         marshaller.marshal(element, sw)
+
+        shouldNotThrowAny {
+            validator.validate(JAXBSource(jaxbContext, element))}
 
         val unmarshaller = jaxbContext.createUnmarshaller()
         val parsedArkivmelding: Arkivmelding = unmarshaller.unmarshal(sw.toString().byteInputStream()) as Arkivmelding

--- a/fiks-arkiv-forenklet-arkivering/src/main/kotlin/no/ks/fiks/io/arkiv/model/arkivmelding/ArkivnotatBuilder.kt
+++ b/fiks-arkiv-forenklet-arkivering/src/main/kotlin/no/ks/fiks/io/arkiv/model/arkivmelding/ArkivnotatBuilder.kt
@@ -5,6 +5,7 @@ import no.ks.fiks.io.arkiv.model.metadatakatalog.v2.DokumentmediumType
 import no.ks.fiks.io.arkiv.model.metadatakatalog.v2.KodeBuilder
 import no.ks.fiks.io.arkiv.model.metadatakatalog.v2.SystemIDBuilder
 import no.ks.fiks.io.arkiv.v1.client.models.arkivmelding.Arkivnotat
+import no.ks.fiks.io.arkiv.v1.client.models.arkivmelding.ReferanseForelderMappe
 import java.time.LocalDate
 import java.time.ZonedDateTime
 import java.util.*
@@ -22,7 +23,7 @@ class ArkivnotatBuilder : IRegistrering {
         private set
     var arkivertAv: String? = null
         private set
-    var referanseForelderMappe: SystemIDBuilder? = null
+    var referanseForelderMappe: ReferanseForelderMappeBuilder? = null
         private set
     var arkivdel: KodeBuilder? = null
         private set
@@ -86,7 +87,7 @@ class ArkivnotatBuilder : IRegistrering {
     fun opprettetAv(opprettetAv: String) = apply { this.opprettetAv = opprettetAv }
     fun arkivertDato(arkivertDato: ZonedDateTime) = apply { this.arkivertDato = arkivertDato }
     fun arkivertAv(arkivertAv: String) = apply { this.arkivertAv = arkivertAv }
-    fun referanseForelderMappe(referanseForelderMappe: SystemIDBuilder) = apply { if(arkivdel == null) this.referanseForelderMappe = referanseForelderMappe else throw IllegalArgumentException("ReferanseForelderMappe kan ikke settes i kombinasjon med ReferanseArkivdel") }
+    fun referanseForelderMappe(referanseForelderMappe: ReferanseForelderMappeBuilder) = apply { if(arkivdel == null) this.referanseForelderMappe = referanseForelderMappe else throw IllegalArgumentException("ReferanseForelderMappe kan ikke settes i kombinasjon med ReferanseArkivdel") }
     fun arkivdel(arkivdel: KodeBuilder) = apply { if(referanseForelderMappe == null) this.arkivdel = arkivdel else throw IllegalArgumentException("ReferanseArkivdel kan ikke settes i kombinasjon med ReferanseForelderMappe") }
     fun korrespondanseparts(korrespondanseparts: List<KorrespondansepartBuilder>) = apply { this.korrespondanseparts = korrespondanseparts }
     fun referanseEksternNoekkel(referanseEksternNoekkel: EksternNoekkelBuilder) = apply { this.referanseEksternNoekkel =  referanseEksternNoekkel}

--- a/fiks-arkiv-forenklet-arkivering/src/main/kotlin/no/ks/fiks/io/arkiv/model/arkivmelding/JournalpostBuilder.kt
+++ b/fiks-arkiv-forenklet-arkivering/src/main/kotlin/no/ks/fiks/io/arkiv/model/arkivmelding/JournalpostBuilder.kt
@@ -37,7 +37,7 @@ open class JournalpostBuilder : IRegistrering {
         private set
     var arkivertAv: String? = null
         private set
-    var referanseForelderMappe: SystemIDBuilder? = null
+    var referanseForelderMappe: ReferanseForelderMappeBuilder? = null
         private set
     var korrespondanseparts: List<KorrespondansepartBuilder> = ArrayList()
         private set
@@ -105,7 +105,7 @@ open class JournalpostBuilder : IRegistrering {
     fun opprettetAv(opprettetAv: String) = apply { this.opprettetAv = opprettetAv }
     fun arkivertDato(arkivertDato: ZonedDateTime) = apply { this.arkivertDato = arkivertDato }
     fun arkivertAv(arkivertAv: String) = apply { this.arkivertAv = arkivertAv }
-    fun referanseForelderMappe(referanseForelderMappe: SystemIDBuilder) = apply { if(arkivdel == null) this.referanseForelderMappe = referanseForelderMappe else throw IllegalArgumentException("ReferanseForelderMappe kan ikke settes i kombinasjon med ReferanseArkivdel") }
+    fun referanseForelderMappe(referanseForelderMappe: ReferanseForelderMappeBuilder) = apply { if(arkivdel == null) this.referanseForelderMappe = referanseForelderMappe else throw IllegalArgumentException("ReferanseForelderMappe kan ikke settes i kombinasjon med ReferanseArkivdel") }
     fun arkivdel(arkivdel: KodeBuilder) = apply { if(referanseForelderMappe == null) this.arkivdel = arkivdel else throw IllegalArgumentException("ReferanseArkivdel kan ikke settes i kombinasjon med ReferanseForelderMappe") }
     fun korrespondanseparts(korrespondanseparts: List<KorrespondansepartBuilder>) = apply { this.korrespondanseparts = korrespondanseparts }
     fun journalstatus(journalstatus: JournalStatus) = apply { this.journalstatus = journalstatus }

--- a/fiks-arkiv-forenklet-arkivering/src/main/kotlin/no/ks/fiks/io/arkiv/model/arkivmelding/MappeBuilder.kt
+++ b/fiks-arkiv-forenklet-arkivering/src/main/kotlin/no/ks/fiks/io/arkiv/model/arkivmelding/MappeBuilder.kt
@@ -15,7 +15,7 @@ open class MappeBuilder {
         private set
     var mappeId: String? = null
         private set
-    var referanseForeldermappe: SystemIDBuilder? = null
+    var referanseForeldermappe: ReferanseForelderMappeBuilder? = null
         private set
     var tittel: String? = null
         private set
@@ -62,7 +62,7 @@ open class MappeBuilder {
 
     fun systemID(systemID: SystemIDBuilder) = apply { this.systemID = systemID }
     fun mappeId(mappeId: String) = apply { this.mappeId = mappeId }
-    fun referanseForeldermappe(referanseForeldermappe: SystemIDBuilder) = apply { this.referanseForeldermappe = referanseForeldermappe }
+    fun referanseForeldermappe(referanseForeldermappe: ReferanseForelderMappeBuilder) = apply { this.referanseForeldermappe = referanseForeldermappe }
     fun tittel(tittel: String) = apply { this.tittel = tittel }
     fun offentligTittel(offentligTittel: String) = apply { this.offentligTittel = offentligTittel }
     fun beskrivelse(beskrivelse: String) = apply { this.beskrivelse =  beskrivelse }

--- a/fiks-arkiv-forenklet-arkivering/src/main/kotlin/no/ks/fiks/io/arkiv/model/arkivmelding/ReferanseForelderMappeBuilder.kt
+++ b/fiks-arkiv-forenklet-arkivering/src/main/kotlin/no/ks/fiks/io/arkiv/model/arkivmelding/ReferanseForelderMappeBuilder.kt
@@ -1,0 +1,26 @@
+package no.ks.fiks.io.arkiv.model.arkivmelding
+
+import no.ks.fiks.io.arkiv.model.arkivstruktur.EksternNoekkelBuilder
+import no.ks.fiks.io.arkiv.model.metadatakatalog.v2.SystemIDBuilder
+import no.ks.fiks.io.arkiv.v1.client.models.arkivmelding.ReferanseForelderMappe
+
+class ReferanseForelderMappeBuilder {
+    var systemID: SystemIDBuilder? = null
+        private set
+    var referanseEksternNoekkel: EksternNoekkelBuilder? = null
+        private set
+    var saksnummer: SaksnummerBuilder? = null
+        private set
+
+    fun systemID(systemID: SystemIDBuilder) = apply { if(referanseEksternNoekkel == null && saksnummer == null) this.systemID = systemID else throw IllegalArgumentException("Det er ikke mulig å registrere både systemID og referanseEksternNoekkel eller saksnummer på ReferanseForelderMappe") }
+    fun referanseEksternNoekkel(referanseEksternNoekkel: EksternNoekkelBuilder) = apply { if(systemID == null && saksnummer == null) this.referanseEksternNoekkel = referanseEksternNoekkel else throw IllegalArgumentException("Det er ikke mulig å registrere både referanseEksternNoekkel og systemID eller saksnummer på ReferanseForelderMappe") }
+    fun saksnummer(saksnummer: SaksnummerBuilder) = apply { if(systemID == null && referanseEksternNoekkel == null) this.saksnummer = saksnummer else throw IllegalArgumentException("Det er ikke mulig å registrere både saksnummer og referanseEksternNoekkel eller systemID på ReferanseForelderMappe") }
+
+    fun build() : ReferanseForelderMappe {
+        return ReferanseForelderMappe().also {
+            it.systemID = systemID?.build()
+            it.referanseEksternNoekkel = referanseEksternNoekkel?.build()
+            it.saksnummer = saksnummer?.build()
+        }
+    }
+}

--- a/fiks-arkiv-forenklet-arkivering/src/main/kotlin/no/ks/fiks/io/arkiv/model/arkivmelding/SaksnummerBuilder.kt
+++ b/fiks-arkiv-forenklet-arkivering/src/main/kotlin/no/ks/fiks/io/arkiv/model/arkivmelding/SaksnummerBuilder.kt
@@ -1,0 +1,20 @@
+package no.ks.fiks.io.arkiv.model.arkivmelding
+
+import no.ks.fiks.io.arkiv.v1.client.models.arkivmelding.Saksnummer
+
+class SaksnummerBuilder {
+    var saksaar: Long? = null
+        private set
+    var sakssekvensnummer: Long? = null
+        private set
+
+    fun saksaar(saksaar: Long) = apply { this.saksaar = saksaar }
+    fun sakssekvensnummer(sakssekvensnummer: Long) = apply { this.sakssekvensnummer = sakssekvensnummer }
+
+    fun build() : Saksnummer {
+        return Saksnummer().also {
+            it.saksaar = saksaar?.toBigInteger()
+            it.sakssekvensnummer = sakssekvensnummer?.toBigInteger()
+        }
+    }
+}

--- a/fiks-arkiv-forenklet-arkivering/src/test/java/no/ks/fiks/io/arkiv/model/ArkivmeldingJavaTest.java
+++ b/fiks-arkiv-forenklet-arkivering/src/test/java/no/ks/fiks/io/arkiv/model/ArkivmeldingJavaTest.java
@@ -37,10 +37,10 @@ public class ArkivmeldingJavaTest {
                                 .value(UUID.randomUUID())
                                 .label("SystemId label"))
                         .mappeId("mappeId")
-                        .referanseForeldermappe(
+                        .referanseForeldermappe(new ReferanseForelderMappeBuilder().systemID(
                                 new SystemIDBuilder()
                                         .value(UUID.randomUUID())
-                                        .label("label"))
+                                        .label("label")))
                         .tittel("Mappe tittel");
 
         ArkivmeldingBuilder arkivmeldingBuilder = new MappeArkivmeldingBuilder()

--- a/fiks-arkiv-forenklet-arkivering/src/test/kotlin/no/ks/fiks/io/arkiv/model/ArkivmeldingTest.kt
+++ b/fiks-arkiv-forenklet-arkivering/src/test/kotlin/no/ks/fiks/io/arkiv/model/ArkivmeldingTest.kt
@@ -8,6 +8,7 @@ import no.ks.fiks.io.arkiv.model.arkivmelding.RegistreringArkivmeldingBuilder
 import no.ks.fiks.io.arkiv.model.arkivstruktur.EksternNoekkelBuilder
 import no.ks.fiks.io.arkiv.model.arkivmelding.JournalpostBuilder
 import no.ks.fiks.io.arkiv.model.arkivmelding.KorrespondansepartBuilder
+import no.ks.fiks.io.arkiv.model.arkivmelding.ReferanseForelderMappeBuilder
 import no.ks.fiks.io.arkiv.model.metadatakatalog.v2.JournalStatus
 import no.ks.fiks.io.arkiv.model.metadatakatalog.v2.JournalpostType
 import no.ks.fiks.io.arkiv.model.metadatakatalog.v2.KorrespondansepartType
@@ -49,7 +50,7 @@ class ArkivmeldingTest {
                 .opprettetAv("Tester")
                 .arkivertDato(ZonedDateTime.now())
                 .arkivertAv("Mr. Arkiv")
-                .referanseForelderMappe(SystemIDBuilder().value(UUID.randomUUID()).label("registreringLabel"))
+                .referanseForelderMappe(ReferanseForelderMappeBuilder().systemID(SystemIDBuilder().value(UUID.randomUUID()).label("registreringLabel")))
                 .referanseEksternNoekkel(EksternNoekkelBuilder().fagstystem("Faglig").noekkel("key"))
                 .korrespondanseparts(listOf(
                     KorrespondansepartBuilder()
@@ -99,7 +100,7 @@ class ArkivmeldingTest {
                 .opprettetAv("Tester")
                 .arkivertDato(ZonedDateTime.now())
                 .arkivertAv("Mr. Arkiv")
-                .referanseForelderMappe(SystemIDBuilder().value(UUID.randomUUID()).label("registreringLabel"))
+                .referanseForelderMappe(ReferanseForelderMappeBuilder().systemID(SystemIDBuilder().value(UUID.randomUUID()).label("registreringLabel")))
                 .referanseEksternNoekkel(EksternNoekkelBuilder().fagstystem("Faglig").noekkel("key"))
                 .korrespondanseparts(listOf(
                     KorrespondansepartBuilder()


### PR DESCRIPTION
- Oppdatert bindings. Complex type "inkluder" var definert i dokumentfilHent, journalpostHent og mappeHent. Krever at disse derfor defineres i egne mapper for å ungå konflikt.
- Akrivnotat, Journalpost og Mappe har endret type for referanseForeldermappe fra SystemID til ReferanseForelderMappe