### PR TITLE
La til for manglende xsd og de som er endret navn på

### DIFF
--- a/fiks-arkiv-api/src/main/xjb/bindings.xjb
+++ b/fiks-arkiv-api/src/main/xjb/bindings.xjb
@@ -29,14 +29,29 @@
             <jaxb:package name="no.ks.fiks.arkiv.v1.arkivstruktur" />
         </jaxb:schemaBindings>
     </jaxb:bindings>
-    <jaxb:bindings schemaLocation="../../../target/schemas/v1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.xsd">
+    <jaxb:bindings schemaLocation="../../../target/schemas/v1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.xsd">
         <jaxb:schemaBindings>
-            <jaxb:package name="no.ks.fiks.arkiv.v1.arkivmelding" />
+            <jaxb:package name="no.ks.fiks.arkiv.v1.arkivmelding.opprett" />
         </jaxb:schemaBindings>
     </jaxb:bindings>
-    <jaxb:bindings schemaLocation="../../../target/schemas/v1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.kvittering.xsd">
+    <jaxb:bindings schemaLocation="../../../target/schemas/v1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.kvittering.xsd">
         <jaxb:schemaBindings>
             <jaxb:package name="no.ks.fiks.arkiv.v1.arkivmelding.kvittering" />
+        </jaxb:schemaBindings>
+    </jaxb:bindings>
+    <jaxb:bindings schemaLocation="../../../target/schemas/v1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater.xsd">
+        <jaxb:schemaBindings>
+            <jaxb:package name="no.ks.fiks.arkiv.v1.arkivmelding.oppdater" />
+        </jaxb:schemaBindings>
+    </jaxb:bindings>
+    <jaxb:bindings schemaLocation="../../../target/schemas/v1/no.ks.fiks.arkiv.v1.arkivering.dokumentobjekt.opprett.xsd">
+        <jaxb:schemaBindings>
+            <jaxb:package name="no.ks.fiks.arkiv.v1.dokumentobjekt.opprett" />
+        </jaxb:schemaBindings>
+    </jaxb:bindings>
+    <jaxb:bindings schemaLocation="../../../target/schemas/v1/no.ks.fiks.arkiv.v1.arkivering.dokumentobjekt.opprett.kvittering.xsd">
+        <jaxb:schemaBindings>
+            <jaxb:package name="no.ks.fiks.arkiv.v1.dokumentobjekt.opprett.kvittering" />
         </jaxb:schemaBindings>
     </jaxb:bindings>
     <jaxb:bindings schemaLocation="../../../target/schemas/v1/no.ks.fiks.arkiv.v1.innsyn.dokumentfil.hent.xsd">
@@ -60,6 +75,16 @@
         </jaxb:schemaBindings>
     </jaxb:bindings>
     <jaxb:bindings schemaLocation="../../../target/schemas/v1/no.ks.fiks.arkiv.v1.innsyn.sok.resultat.minimum.xsd">
+        <jaxb:schemaBindings>
+            <jaxb:package name="no.ks.fiks.arkiv.v1.innsyn.sok" />
+        </jaxb:schemaBindings>
+    </jaxb:bindings>
+    <jaxb:bindings schemaLocation="../../../target/schemas/v1/no.ks.fiks.arkiv.v1.innsyn.sok.resultat.noekler.xsd">
+        <jaxb:schemaBindings>
+            <jaxb:package name="no.ks.fiks.arkiv.v1.innsyn.sok" />
+        </jaxb:schemaBindings>
+    </jaxb:bindings>
+    <jaxb:bindings schemaLocation="../../../target/schemas/v1/no.ks.fiks.arkiv.v1.innsyn.sok.resultat.utvidet.xsd">
         <jaxb:schemaBindings>
             <jaxb:package name="no.ks.fiks.arkiv.v1.innsyn.sok" />
         </jaxb:schemaBindings>

--- a/fiks-arkiv-api/src/test/kotlin/no/ks/fiks/io/arkiv/model/ArkivmeldingTest.kt
+++ b/fiks-arkiv-api/src/test/kotlin/no/ks/fiks/io/arkiv/model/ArkivmeldingTest.kt
@@ -93,11 +93,11 @@ class ArkivmeldingTest {
 
         val jaxbContext = JAXBContext.newInstance(Arkivmelding::class.java)
         val schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
-        val schema = schemaFactory.newSchema(File("target/schemas/v1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.xsd"))
+        val schema = schemaFactory.newSchema(File("target/schemas/v1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.xsd"))
         val validator = schema.newValidator()
 
         val element = JAXBElement(
-            QName("https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivmelding/v1", "arkivmelding"),
+            QName("https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivmelding/opprett/v1", "arkivmelding"),
             Arkivmelding::class.java,
             arkivmelding)
 


### PR DESCRIPTION
Vi endret navn på arkivmelding til arkivmelding.opprett.
Det har kommet 2 nye xsd og meldingstyper for dokumentobjekt.opprett og kvittering. 
Samtidig så det ut til at det manglet noen xsd'er?