### PR TITLE
Lagt til de nye xsd'ene for avskrivning

### DIFF
--- a/fiks-arkiv-api/src/main/xjb/bindings.xjb
+++ b/fiks-arkiv-api/src/main/xjb/bindings.xjb
@@ -54,6 +54,16 @@
             <jaxb:package name="no.ks.fiks.arkiv.v1.dokumentobjekt.opprett.kvittering" />
         </jaxb:schemaBindings>
     </jaxb:bindings>
+    <jaxb:bindings schemaLocation="../../../target/schemas/v1/no.ks.fiks.arkiv.v1.arkivering.avskrivning.opprett.xsd">
+        <jaxb:schemaBindings>
+            <jaxb:package name="no.ks.fiks.arkiv.v1.avskrivning.opprett" />
+        </jaxb:schemaBindings>
+    </jaxb:bindings>
+    <jaxb:bindings schemaLocation="../../../target/schemas/v1/no.ks.fiks.arkiv.v1.arkivering.avskrivning.slett.xsd">
+        <jaxb:schemaBindings>
+            <jaxb:package name="no.ks.fiks.arkiv.v1.avskrivning.slett" />
+        </jaxb:schemaBindings>
+    </jaxb:bindings>
     <jaxb:bindings schemaLocation="../../../target/schemas/v1/no.ks.fiks.arkiv.v1.innsyn.dokumentfil.hent.xsd">
         <jaxb:schemaBindings>
             <jaxb:package name="no.ks.fiks.arkiv.v1.innsyn.dokument" />

--- a/fiks-arkiv-api/src/test/kotlin/no/ks/fiks/io/arkiv/model/ArkivmeldingTest.kt
+++ b/fiks-arkiv-api/src/test/kotlin/no/ks/fiks/io/arkiv/model/ArkivmeldingTest.kt
@@ -27,7 +27,7 @@ class ArkivmeldingTest {
         val arkivertDato = ZonedDateTime.now()
 
         val arkivmelding = Arkivmelding().also {
-            it.registrerings.addAll(listOf(Journalpost().also {
+            it.registrering = Journalpost().also {
                 it.dokumentetsDato = journalDate
                 it.mottattDato = arkivertDato
                 it.sendtDato = arkivertDato
@@ -85,7 +85,7 @@ class ArkivmeldingTest {
                     it.kode = "S"
                     it.beskrivelse = "Beskrivelse"
                 }
-            }))
+            }
             it.system = "System"
             it.tidspunkt = ZonedDateTime.now()
             it.antallFiler = 2
@@ -111,7 +111,7 @@ class ArkivmeldingTest {
         val unmarshaller = jaxbContext.createUnmarshaller()
         val parsedArkivmelding: Arkivmelding = unmarshaller.unmarshal(sw.toString().byteInputStream()) as Arkivmelding
 
-        (parsedArkivmelding.registrerings[0] as Journalpost).journaldato.format(java.time.format.DateTimeFormatter.ISO_LOCAL_DATE) shouldBe journalDate.format(java.time.format.DateTimeFormatter.ISO_LOCAL_DATE)
-        (parsedArkivmelding.registrerings[0] as Journalpost).arkivertDato.format(java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME) shouldBe arkivertDato.format(java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+        (parsedArkivmelding.registrering as Journalpost).journaldato.format(java.time.format.DateTimeFormatter.ISO_LOCAL_DATE) shouldBe journalDate.format(java.time.format.DateTimeFormatter.ISO_LOCAL_DATE)
+        (parsedArkivmelding.registrering as Journalpost).arkivertDato.format(java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME) shouldBe arkivertDato.format(java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME)
     }
 }

--- a/fiks-arkiv-forenklet-arkivering/src/main/kotlin/no/ks/fiks/io/arkiv/model/arkivmelding/MappeArkivmeldingBuilder.kt
+++ b/fiks-arkiv-forenklet-arkivering/src/main/kotlin/no/ks/fiks/io/arkiv/model/arkivmelding/MappeArkivmeldingBuilder.kt
@@ -5,14 +5,14 @@ import no.ks.fiks.arkiv.v1.arkivmelding.opprett.Mappe
 
 class MappeArkivmeldingBuilder: ArkivmeldingBuilder() {
 
-    var mapper: List<Mappe> = emptyList()
+    var mappe: Mappe = Mappe()
         private set
 
-    fun mapper(mapper: List<Mappe>) = apply { this.mapper = mapper }
+    fun mappe(mappe: Mappe) = apply { this.mappe = mappe }
 
     override fun build(): Arkivmelding {
         return super.build().also {
-            it.mappes.addAll(mapper)
+            it.mappe = mappe
         }
     }
 

--- a/fiks-arkiv-forenklet-arkivering/src/main/kotlin/no/ks/fiks/io/arkiv/model/arkivmelding/MappeBuilder.kt
+++ b/fiks-arkiv-forenklet-arkivering/src/main/kotlin/no/ks/fiks/io/arkiv/model/arkivmelding/MappeBuilder.kt
@@ -9,7 +9,7 @@ import no.ks.fiks.io.arkiv.model.metadatakatalog.v2.DokumentmediumType
 import java.time.ZonedDateTime
 
 /**
- * Mappe er det overordnede objektet for å samle saker i. Det er mulig å ha mapper i mapper.
+ * Mappe er det overordnede objektet for å samle saker i. Det er mulig å ha mapper i mapper men ikke i en arkivmelding.
  */
 open class MappeBuilder {
     var systemID: SystemID? = null
@@ -54,10 +54,6 @@ open class MappeBuilder {
         private set
     var referanseEksternNoekkel: EksternNoekkel? = null
         private set
-    var registreringer: List<IRegistrering> = emptyList()
-        private set
-    var mapper: List<Mappe> = emptyList()
-        private set
     var mappetype: Kode? = null
         private set
 
@@ -82,8 +78,6 @@ open class MappeBuilder {
     fun gradering(gradering: Gradering) = apply { this.gradering = gradering }
     fun klassifikasjoner(klassifikasjoner: List<Klassifikasjon>) = apply { this.klassifikasjoner = klassifikasjoner }
     fun referanseEksternNoekkel(referanseEksternNoekkel: EksternNoekkel) = apply { this.referanseEksternNoekkel = referanseEksternNoekkel }
-    fun registreringer(registreringer: List<IRegistrering>) = apply { if(mapper.isEmpty()) this.registreringer = registreringer else throw IllegalArgumentException("Det er ikke mulig å registrere både undermapper og registreringer til samme mappe") }
-    fun mapper(mapper: List<Mappe>) = apply { if(mapper.isEmpty()) this.mapper = mapper else throw IllegalArgumentException("Det er ikke mulig å registrere både undermapper og registreringer til samme mappe") }
     fun mappetype(mappetype: Kode) = apply { this.mappetype = mappetype }
 
     open fun build(): Mappe {
@@ -109,8 +103,6 @@ open class MappeBuilder {
             it.gradering = gradering
             it.klassifikasjons.addAll(klassifikasjoner)
             it.referanseEksternNoekkel = referanseEksternNoekkel
-            it.registrerings.addAll(registreringer.map { r -> r.build() }.toList())
-            it.mappes.addAll(mapper)
             it.mappetype = mappetype
         }
     }

--- a/fiks-arkiv-forenklet-arkivering/src/main/kotlin/no/ks/fiks/io/arkiv/model/arkivmelding/RegistreringArkivmeldingBuilder.kt
+++ b/fiks-arkiv-forenklet-arkivering/src/main/kotlin/no/ks/fiks/io/arkiv/model/arkivmelding/RegistreringArkivmeldingBuilder.kt
@@ -4,14 +4,14 @@ import no.ks.fiks.arkiv.v1.arkivmelding.opprett.Arkivmelding
 
 class RegistreringArkivmeldingBuilder: ArkivmeldingBuilder() {
 
-    var registrering: List<IRegistrering>? = emptyList()
+    lateinit var registrering: IRegistrering
         private set
 
-    fun registrering(registrering: List<IRegistrering>) = apply { this.registrering = registrering }
+    fun registrering(registrering: IRegistrering) = apply { this.registrering = registrering }
 
     override fun build(): Arkivmelding {
         return super.build().also {
-            it.registrerings.addAll( registrering?.map { m -> m.build() }?.toList() ?: emptyList() )
+            it.registrering = this.registrering.build()
         }
     }
 

--- a/fiks-arkiv-forenklet-arkivering/src/main/kotlin/no/ks/fiks/io/arkiv/model/arkivmelding/SaksmappeBuilder.kt
+++ b/fiks-arkiv-forenklet-arkivering/src/main/kotlin/no/ks/fiks/io/arkiv/model/arkivmelding/SaksmappeBuilder.kt
@@ -7,7 +7,7 @@ import no.ks.fiks.io.arkiv.model.metadatakatalog.v2.SaksstatusType
 import java.time.LocalDate
 
 /**
- * Mappe er det overordnede objektet for å samle saker i. Det er mulig å ha mapper i mapper.
+ * Mappe er det overordnede objektet for å samle saker i. Det er mulig å ha mapper i mapper men ikke i en arkivmelding.
  */
 open class SaksmappeBuilder : MappeBuilder() {
     var saksaar: Int? = null
@@ -80,10 +80,7 @@ open class SaksmappeBuilder : MappeBuilder() {
             it.gradering = gradering
             it.klassifikasjons.addAll(klassifikasjoner)
             it.referanseEksternNoekkel = referanseEksternNoekkel
-            it.registrerings.addAll(registreringer.map { r -> r.build() }.toList())
-            it.mappes.addAll(mapper)
             it.mappetype = mappetype
-
             it.saksaar = saksaar
             it.sakssekvensnummer = sakssekvensnummer
             it.saksdato = saksdato

--- a/fiks-arkiv-forenklet-arkivering/src/main/kotlin/no/ks/fiks/io/arkiv/model/forenklet/ArkivmeldingForenkletUtgaaende.kt
+++ b/fiks-arkiv-forenklet-arkivering/src/main/kotlin/no/ks/fiks/io/arkiv/model/forenklet/ArkivmeldingForenkletUtgaaende.kt
@@ -95,13 +95,13 @@ class ArkivmeldingForenkletUtgaaende {
             val saksMappeBuilder = opprettSaksmappe(saksmappe, journalpost)
 
             val arkivmelding = MappeArkivmeldingBuilder()
-                .mapper(listOf(saksMappeBuilder.build()))
+                .mappe(saksMappeBuilder.build())
                 .antallFiler(journalpost.dokumentbeskrivelser.size)
             journalpost.referanseEksternNoekkel?.fagsystem?.let { fs -> arkivmelding.system(fs) }
             return arkivmelding
         } ?: run {
             val arkivmelding = RegistreringArkivmeldingBuilder()
-                .registrering(listOf(journalpost))
+                .registrering(journalpost)
                 .antallFiler(journalpost.dokumentbeskrivelser.size)
             journalpost.referanseEksternNoekkel?.fagsystem?.let { fs -> arkivmelding.system(fs) }
             return arkivmelding
@@ -135,7 +135,6 @@ class ArkivmeldingForenkletUtgaaende {
             mappeBuilder(noekkel, saksMappeBuilder)
         }
 
-        saksMappeBuilder.registreringer(listOf(journalpost))
         return saksMappeBuilder
     }
 

--- a/fiks-arkiv-forenklet-arkivering/src/test/java/no/ks/fiks/io/arkiv/model/ArkivmeldingJavaTest.java
+++ b/fiks-arkiv-forenklet-arkivering/src/test/java/no/ks/fiks/io/arkiv/model/ArkivmeldingJavaTest.java
@@ -45,7 +45,7 @@ public class ArkivmeldingJavaTest {
                         .tittel("Mappe tittel");
 
         ArkivmeldingBuilder arkivmeldingBuilder = new MappeArkivmeldingBuilder()
-                .mapper(Collections.singletonList(mappe.build()))
+                .mappe(mappe.build())
                 .system("System A")
                 .tidspunkt(ZonedDateTime.now())
                 .antallFiler(0);
@@ -82,7 +82,7 @@ public class ArkivmeldingJavaTest {
                 .journalpostnummer(222);
 
         ArkivmeldingBuilder arkivmeldingBuilder = new RegistreringArkivmeldingBuilder()
-                .registrering(Collections.singletonList(journalPostBuilder))
+                .registrering(journalPostBuilder)
                 .system("System A")
                 .tidspunkt(ZonedDateTime.now())
                 .antallFiler(1);
@@ -119,8 +119,7 @@ public class ArkivmeldingJavaTest {
                 .poststed("Bø").build());
 
 
-        final List<JournalpostBuilder> journalposter = Collections.singletonList(
-                new JournalpostBuilder()
+        final JournalpostBuilder journalpost = new JournalpostBuilder()
                         .avskrivningsdato(LocalDate.now())
                         .journalposttype(JournalpostType.UTGAENDE_DOKUMENT)
                         .journalstatus(JournalStatus.JOURNALFORT)
@@ -159,9 +158,9 @@ public class ArkivmeldingJavaTest {
                                                                     .sjekksumAlgoritme("hash")
                                                                     .filstoerrelse(12345)
                                                                     .referanseDokumentfil("/en/path")
-                                                                    .format(FormatType.PDF_A_ISO_19005_1_2005).build())).build())));
+                                                                    .format(FormatType.PDF_A_ISO_19005_1_2005).build())).build()));
         ArkivmeldingBuilder arkivmeldingBuilder = new RegistreringArkivmeldingBuilder()
-                .registrering(journalposter)
+                .registrering(journalpost)
                 .system("Fagsystem X")
                 .antallFiler(1);
 

--- a/fiks-arkiv-forenklet-arkivering/src/test/kotlin/no/ks/fiks/io/arkiv/model/ArkivmeldingTest.kt
+++ b/fiks-arkiv-forenklet-arkivering/src/test/kotlin/no/ks/fiks/io/arkiv/model/ArkivmeldingTest.kt
@@ -71,7 +71,7 @@ class ArkivmeldingTest {
                 ))
 
         val arkivmelding = RegistreringArkivmeldingBuilder()
-            .registrering(listOf(registrering))
+            .registrering(registrering)
             .system("systemA")
             .tidspunkt(ZonedDateTime.now())
             .antallFiler(2)
@@ -126,7 +126,7 @@ class ArkivmeldingTest {
                 ))
 
         val arkivmelding = RegistreringArkivmeldingBuilder()
-            .registrering(listOf(registrering))
+            .registrering(registrering)
             .antallFiler(1)
             .tidspunkt(ZonedDateTime.now())
 


### PR DESCRIPTION
Lagt til de nye xsd'ene for avskrivning i bindings.xjb.
Det er også endringer i skjema mtp at det nå ikke lenger er lister med registreringer og mapper i arkivmelding, men kun en og en registrering og mappe. Dette medførte endringer i tester samt forenklet arkivering.